### PR TITLE
refactor: move db dependency into router

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,121 +1,17 @@
-from fastapi import FastAPI, Depends, Query, HTTPException, Body
-from typing import List
-from sqlalchemy.orm import Session
-from sqlalchemy.sql.expression import func
-from database import Base, engine, SessionLocal
-from models import Book, Result
 import os
+
 from dotenv import load_dotenv
+from fastapi import FastAPI
+
+from database import Base, engine
+from router import books_router
 
 load_dotenv(os.path.join(os.path.dirname(__file__), "..", ".env"))
-app = FastAPI()
 
+app = FastAPI()
 
 # 初回起動時にDBテーブルを自動作成
 Base.metadata.create_all(bind=engine)
 
-
-# DBセッションをリクエストごとに管理
-def get_db():
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
-
-
-@app.get("/")
-def root():
-    return {"message": "Hello, FastAPI!"}
-
-
-# ランダムで指定数の書籍を取得するエンドポイント
-@app.get("/books/pick/")
-def pick_books(
-    db: Session = Depends(get_db),
-    include_picked: int = Query(0, description="1でis_picked=1も含める。"),
-):
-    pickcount = int(os.getenv("PICKCOUNT", 4))
-
-    if include_picked == 0:
-        query = db.query(Book).filter(Book.is_picked != 1)
-    else:
-        query = db.query(Book)
-
-    books = query.order_by(func.random()).limit(pickcount).all()
-    return books
-
-
-@app.post("/books/")
-def create_book(
-    title: str,
-    author: str,
-    description: str = None,
-    note: str = None,
-    db: Session = Depends(get_db),
-):
-    book = Book(title=title, author=author, description=description, note=note)
-    db.add(book)
-    db.commit()
-    db.refresh(book)
-    return book
-
-
-@app.get("/books/")
-def read_books(db: Session = Depends(get_db)):
-    return db.query(Book).all()
-
-
-@app.get("/books/ids/")
-def get_books_by_ids(id: List[int] = Query(...), db: Session = Depends(get_db)):
-    books = db.query(Book).filter(Book.id.in_(id)).all()
-    return books
-
-
-# 配列指定のid書籍のis_pickedを1にするエンドポイント
-@app.post("/books/picked")
-def update_is_picked(ids: list[int] = Body(...), db: Session = Depends(get_db)):
-    books = db.query(Book).filter(Book.id.in_(ids)).all()
-    if not books:
-        raise HTTPException(status_code=404, detail="Books not found")
-    for book in books:
-        book.is_picked = 1
-    db.commit()
-    return books
-
-
-# 配列指定の書籍のis_pickedをNULLにするエンドポイント
-@app.post("/books/unpicked")
-def unpick_book(ids: list[int] = Body(...), db: Session = Depends(get_db)):
-    books = db.query(Book).filter(Book.id.in_(ids)).all()
-    if not books:
-        raise HTTPException(status_code=404, detail="Books not found")
-    for book in books:
-        book.is_picked = None
-    db.commit()
-    db.refresh(book)
-    return book
-
-
-# 結果を登録するエンドポイント
-@app.post("/results/")
-def create_result(
-    book_ids: list[int] = Body(...),
-    note: str = None,
-    db: Session = Depends(get_db),
-):
-    from datetime import datetime
-    import json
-
-    created_at = datetime.now().isoformat()
-    result = Result(book_ids=json.dumps(book_ids), note=note, created_at=created_at)
-    db.add(result)
-    db.commit()
-    db.refresh(result)
-    return result
-
-
-# 結果を取得するエンドポイント
-@app.get("/results/")
-def read_results(db: Session = Depends(get_db)):
-    return db.query(Result).all()
+# ルーターを登録
+app.include_router(books_router)

--- a/backend/app/router/__init__.py
+++ b/backend/app/router/__init__.py
@@ -1,0 +1,3 @@
+from .books import router as books_router
+
+__all__ = ["books_router"]

--- a/backend/app/router/books.py
+++ b/backend/app/router/books.py
@@ -1,0 +1,112 @@
+import json
+import os
+from collections.abc import Generator
+from datetime import datetime
+from typing import List
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+from sqlalchemy.sql.expression import func
+
+from database import SessionLocal
+from models import Book, Result
+
+router = APIRouter()
+
+
+def get_db() -> Generator[Session, None, None]:
+    """リクエストごとにSQLAlchemyセッションを管理する依存関係"""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.get("/")
+def root():
+    return {"message": "Hello, FastAPI!"}
+
+
+@router.get("/books/pick/")
+def pick_books(
+    db: Session = Depends(get_db),
+    include_picked: int = Query(0, description="1でis_picked=1も含める。"),
+):
+    pickcount = int(os.getenv("PICKCOUNT", 4))
+
+    if include_picked == 0:
+        query = db.query(Book).filter(Book.is_picked != 1)
+    else:
+        query = db.query(Book)
+
+    books = query.order_by(func.random()).limit(pickcount).all()
+    return books
+
+
+@router.post("/books/")
+def create_book(
+    title: str,
+    author: str,
+    description: str = None,
+    note: str = None,
+    db: Session = Depends(get_db),
+):
+    book = Book(title=title, author=author, description=description, note=note)
+    db.add(book)
+    db.commit()
+    db.refresh(book)
+    return book
+
+
+@router.get("/books/")
+def read_books(db: Session = Depends(get_db)):
+    return db.query(Book).all()
+
+
+@router.get("/books/ids/")
+def get_books_by_ids(id: List[int] = Query(...), db: Session = Depends(get_db)):
+    books = db.query(Book).filter(Book.id.in_(id)).all()
+    return books
+
+
+@router.post("/books/picked")
+def update_is_picked(ids: list[int] = Body(...), db: Session = Depends(get_db)):
+    books = db.query(Book).filter(Book.id.in_(ids)).all()
+    if not books:
+        raise HTTPException(status_code=404, detail="Books not found")
+    for book in books:
+        book.is_picked = 1
+    db.commit()
+    return books
+
+
+@router.post("/books/unpicked")
+def unpick_book(ids: list[int] = Body(...), db: Session = Depends(get_db)):
+    books = db.query(Book).filter(Book.id.in_(ids)).all()
+    if not books:
+        raise HTTPException(status_code=404, detail="Books not found")
+    for book in books:
+        book.is_picked = None
+    db.commit()
+    db.refresh(book)
+    return book
+
+
+@router.post("/results/")
+def create_result(
+    book_ids: list[int] = Body(...),
+    note: str = None,
+    db: Session = Depends(get_db),
+):
+    created_at = datetime.now().isoformat()
+    result = Result(book_ids=json.dumps(book_ids), note=note, created_at=created_at)
+    db.add(result)
+    db.commit()
+    db.refresh(result)
+    return result
+
+
+@router.get("/results/")
+def read_results(db: Session = Depends(get_db)):
+    return db.query(Result).all()


### PR DESCRIPTION
## Summary
- ルーター配下で使うDBセッション依存関数をbooksルーター内に配置
- mainモジュール・ルーター間のインポートをパッケージ相対に修正

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d283eb4ab48328afca3fee92f8eba8