### PR TITLE
ランダム取得結果の保存・削除機能を追加

### DIFF
--- a/backend/app/router/books.py
+++ b/backend/app/router/books.py
@@ -209,3 +209,17 @@ def read_results(db: Session = Depends(get_db)):
         raise handle_database_error(exc, "results retrieval") from exc
     except Exception as exc:
         raise handle_internal_error(exc, "results retrieval") from exc
+
+
+@router.delete("/results/")
+def delete_all_results(db: Session = Depends(get_db)):
+    try:
+        deleted_count = db.query(Result).delete()
+        db.commit()
+        return {"deleted_count": deleted_count}
+    except SQLAlchemyError as exc:
+        db.rollback()
+        raise handle_database_error(exc, "results deletion") from exc
+    except Exception as exc:
+        db.rollback()
+        raise handle_internal_error(exc, "results deletion") from exc

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 type Book = {
   id: number;
@@ -9,11 +9,36 @@ type Book = {
   note?: string | null;
 };
 
+type Result = {
+  id: number;
+  book_ids: number[];
+  note?: string | null;
+  created_at: string;
+};
+
 export default function Home() {
   const apiBaseUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
   const [apiStatus, setApiStatus] = useState<string>("");
   const [books, setBooks] = useState<Book[]>([]);
   const [message, setMessage] = useState<string>("");
+  const [results, setResults] = useState<Result[]>([]);
+  const [resultMessage, setResultMessage] = useState<string>("");
+
+  const fetchResults = useCallback(async (): Promise<boolean> => {
+    try {
+      const res = await fetch(`${apiBaseUrl}/results/`);
+      if (!res.ok) {
+        throw new Error("リザルト一覧の取得に失敗しました");
+      }
+      const data: Result[] = await res.json();
+      setResults(data);
+      return true;
+    } catch (error) {
+      setResults([]);
+      setResultMessage(`リザルト一覧の取得に失敗しました: ${error}`);
+      return false;
+    }
+  }, [apiBaseUrl]);
 
   useEffect(() => {
     const fetchStatus = async () => {
@@ -29,7 +54,8 @@ export default function Home() {
       }
     };
     fetchStatus();
-  }, [apiBaseUrl]);
+    fetchResults();
+  }, [apiBaseUrl, fetchResults]);
 
   const fetchRandomBooks = async () => {
     setMessage("書籍情報を取得中です...");
@@ -51,6 +77,58 @@ export default function Home() {
     }
   };
 
+  const saveResult = async () => {
+    if (books.length === 0) {
+      setResultMessage("保存できる書籍情報がありません");
+      return;
+    }
+    setResultMessage("リザルトを保存中です...");
+    try {
+      const res = await fetch(`${apiBaseUrl}/results/`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          book_ids: books.map((book) => book.id),
+        }),
+      });
+      if (!res.ok) {
+        throw new Error("リザルトの保存に失敗しました");
+      }
+      await res.json();
+      const succeeded = await fetchResults();
+      if (succeeded) {
+        setResultMessage("リザルトを保存しました");
+      }
+    } catch (error) {
+      setResultMessage(`リザルトの保存に失敗しました: ${error}`);
+    }
+  };
+
+  const deleteAllResults = async () => {
+    if (results.length === 0) {
+      setResultMessage("削除できるリザルトがありません");
+      return;
+    }
+    setResultMessage("リザルトを削除中です...");
+    try {
+      const res = await fetch(`${apiBaseUrl}/results/`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        throw new Error("リザルトの削除に失敗しました");
+      }
+      await res.json();
+      const succeeded = await fetchResults();
+      if (succeeded) {
+        setResultMessage("すべてのリザルトを削除しました");
+      }
+    } catch (error) {
+      setResultMessage(`リザルトの削除に失敗しました: ${error}`);
+    }
+  };
+
   return (
     <main>
       <section>
@@ -60,6 +138,12 @@ export default function Home() {
       <section>
         <button type="button" onClick={fetchRandomBooks}>
           ランダムに書籍情報を取得
+        </button>
+        <button type="button" onClick={saveResult} disabled={books.length === 0}>
+          取得した書籍をリザルトとして保存
+        </button>
+        <button type="button" onClick={deleteAllResults} disabled={results.length === 0}>
+          リザルトを全削除
         </button>
         <div>{message}</div>
         <ul>
@@ -72,6 +156,48 @@ export default function Home() {
             </li>
           ))}
         </ul>
+      </section>
+      <section>
+        <h2>保存済みリザルト</h2>
+        <div>{resultMessage}</div>
+        {results.length === 0 && resultMessage === "" ? (
+          <div>保存されているリザルトはありません</div>
+        ) : null}
+        {results.length === 0 ? null : (
+          <div>
+            {results.map((result) => (
+              <div
+                key={result.id}
+                style={{
+                  border: "1px solid #ccc",
+                  padding: "1rem",
+                  marginBottom: "1rem",
+                }}
+              >
+                <div>リザルトID: {result.id}</div>
+                <div>
+                  保存日時: {new Date(result.created_at).toLocaleString("ja-JP", {
+                    year: "numeric",
+                    month: "2-digit",
+                    day: "2-digit",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                    second: "2-digit",
+                  })}
+                </div>
+                {result.note ? <div>メモ: {result.note}</div> : null}
+                <div>
+                  書籍ID一覧:
+                  <ul>
+                    {result.book_ids.map((bookId) => (
+                      <li key={bookId}>ID: {bookId}</li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </section>
     </main>
   );


### PR DESCRIPTION
## Summary
- 結果一覧を一括削除できるAPIエンドポイントを追加
- フロントエンドで取得済み書籍の保存と一覧表示、全削除ボタンを実装

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d954756f708328b5be92651110829d