### PR TITLE
Add shelves CRUD support across backend and frontend

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -6,12 +6,12 @@ from sqlalchemy.orm import Session, sessionmaker, DeclarativeBase
 
 load_dotenv()
 
-# DATABASE_URLからSQLite URLを構築
-DATABASE_URL = os.getenv("DATABASE_URL")
+# DATABASE_URLからSQLite URLを構築 (未設定の場合はローカルSQLiteを利用)
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./app.db")
 
 engine = create_engine(
     DATABASE_URL,
-    connect_args={"check_same_thread": False},  # SQLite用
+    connect_args={"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {},
 )
 
 SessionLocal = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,7 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from dotenv import load_dotenv
 
 from .database import Base, engine
-from .router import books_router, admin_router, lookup_router
+from .router import books_router, admin_router, shelves_router, lookup_router
 
 load_dotenv(os.path.join(os.path.dirname(__file__), "..", ".env"))
 
@@ -36,4 +36,5 @@ Base.metadata.create_all(bind=engine)
 # ルーターを登録
 app.include_router(admin_router)
 app.include_router(books_router)
+app.include_router(shelves_router)
 app.include_router(lookup_router)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -24,3 +24,11 @@ class Book(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
     )
+
+
+class Shelf(Base):
+    __tablename__ = "shelves"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(100), nullable=False, unique=True, index=True)
+    memo: Mapped[str | None] = mapped_column(Text())

--- a/backend/app/router/__init__.py
+++ b/backend/app/router/__init__.py
@@ -1,5 +1,6 @@
 from .books import router as books_router
 from .admin import router as admin_router
+from .shelves import router as shelves_router
 from ..lookup.router import router as lookup_router
 
-__all__ = ["books_router", "admin_router", "lookup_router"]
+__all__ = ["books_router", "admin_router", "shelves_router", "lookup_router"]

--- a/backend/app/router/shelves.py
+++ b/backend/app/router/shelves.py
@@ -1,0 +1,102 @@
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from ..database import get_db
+from ..models import Shelf
+from ..schemas import ShelfCreate, ShelfRead, ShelfUpdate
+from ..exceptions import handle_database_error, handle_internal_error
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/shelves/", response_model=list[ShelfRead])
+def read_shelves(db: Session = Depends(get_db)):
+    """棚一覧を取得"""
+    logger.info("GET /shelves - Fetching shelf list")
+    shelves = db.query(Shelf).order_by(Shelf.id.asc()).all()
+    logger.info("GET /shelves - Retrieved %s shelves", len(shelves))
+    return shelves
+
+
+@router.get("/shelves/{shelf_id}", response_model=ShelfRead)
+def read_shelf(shelf_id: int, db: Session = Depends(get_db)):
+    """棚詳細を取得"""
+    logger.info("GET /shelves/%s - Fetching shelf detail", shelf_id)
+    shelf = db.query(Shelf).filter(Shelf.id == shelf_id).first()
+    if not shelf:
+        logger.warning("GET /shelves/%s - Shelf not found", shelf_id)
+        raise HTTPException(status_code=404, detail="Shelf not found")
+    return shelf
+
+
+@router.post("/shelves/", response_model=ShelfRead)
+def create_shelf(shelf: ShelfCreate, db: Session = Depends(get_db)):
+    """棚を新規作成"""
+    logger.info("POST /shelves - Creating shelf: name='%s'", shelf.name)
+    try:
+        db_shelf = Shelf(**shelf.model_dump())
+        db.add(db_shelf)
+        db.commit()
+        db.refresh(db_shelf)
+        logger.info("POST /shelves - Created shelf id=%s", db_shelf.id)
+        return db_shelf
+    except SQLAlchemyError as exc:
+        db.rollback()
+        logger.error("POST /shelves - Database error: %s", exc, exc_info=True)
+        raise handle_database_error(exc, "shelf creation") from exc
+    except Exception as exc:  # 念のため予期しない例外を補足
+        db.rollback()
+        logger.error("POST /shelves - Unexpected error: %s", exc, exc_info=True)
+        raise handle_internal_error(exc, "shelf creation") from exc
+
+
+@router.put("/shelves/{shelf_id}", response_model=ShelfRead)
+def update_shelf(shelf_id: int, shelf: ShelfUpdate, db: Session = Depends(get_db)):
+    """棚情報を更新"""
+    logger.info("PUT /shelves/%s - Updating shelf", shelf_id)
+    try:
+        db_shelf = db.query(Shelf).filter(Shelf.id == shelf_id).first()
+        if not db_shelf:
+            logger.warning("PUT /shelves/%s - Shelf not found", shelf_id)
+            raise HTTPException(status_code=404, detail="Shelf not found")
+
+        for key, value in shelf.model_dump(exclude_unset=True).items():
+            setattr(db_shelf, key, value)
+
+        db.commit()
+        db.refresh(db_shelf)
+        logger.info("PUT /shelves/%s - Updated shelf", shelf_id)
+        return db_shelf
+    except HTTPException:
+        raise
+    except SQLAlchemyError as exc:
+        db.rollback()
+        logger.error("PUT /shelves/%s - Database error: %s", shelf_id, exc, exc_info=True)
+        raise handle_database_error(exc, "shelf update") from exc
+
+
+@router.delete("/shelves/{shelf_id}")
+def delete_shelf(shelf_id: int, db: Session = Depends(get_db)):
+    """棚を削除"""
+    logger.info("DELETE /shelves/%s - Deleting shelf", shelf_id)
+    try:
+        shelf = db.query(Shelf).filter(Shelf.id == shelf_id).first()
+        if not shelf:
+            logger.warning("DELETE /shelves/%s - Shelf not found", shelf_id)
+            raise HTTPException(status_code=404, detail="Shelf not found")
+
+        db.delete(shelf)
+        db.commit()
+        logger.info("DELETE /shelves/%s - Deleted shelf", shelf_id)
+        return {"message": "Shelf deleted successfully"}
+    except HTTPException:
+        raise
+    except SQLAlchemyError as exc:
+        db.rollback()
+        logger.error("DELETE /shelves/%s - Database error: %s", shelf_id, exc, exc_info=True)
+        raise handle_database_error(exc, "shelf deletion") from exc

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -65,3 +65,23 @@ class BookRead(BookBase):
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class ShelfBase(BaseModel):
+    name: str
+    memo: str | None = None
+
+
+class ShelfCreate(ShelfBase):
+    pass
+
+
+class ShelfUpdate(BaseModel):
+    name: str | None = None
+    memo: str | None = None
+
+
+class ShelfRead(ShelfBase):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -8,9 +8,11 @@ Book Selector APIのテストスイート
 backend/
 ├── app/              # アプリケーションコード
 ├── tests/            # テストコード
-│   ├── conftest.py   # pytest設定とフィクスチャ
-│   ├── test_books.py # 書籍関連のテスト
-│   └── test_health.py # ヘルスチェックのテスト
+│   ├── conftest.py    # pytest設定とフィクスチャ
+│   ├── test_admin.py  # 管理系エンドポイントのテスト
+│   ├── test_books.py  # 書籍関連のテスト
+│   ├── test_lookup.py # 検索APIのテスト
+│   └── test_shelves.py # 棚関連のテスト
 └── pytest.ini        # pytest設定ファイル
 ```
 
@@ -47,14 +49,19 @@ uv run pytest --lf
 
 ## 現在のテストケース
 
-### test_health.py
-- `test_health_endpoint`: `/health`エンドポイントの正常性確認
-
 ### test_books.py
 - `test_get_books_empty`: 空の書籍リストの取得
 - `test_get_books_with_data`: データがある場合の書籍リスト取得
 - `test_create_book`: 書籍の新規作成
 - `test_create_book_invalid_isbn`: 不正なISBNのバリデーション
+
+### test_shelves.py
+- `test_get_shelves_empty`: 空の棚リスト取得
+- `test_get_shelves_with_data`: 棚データがある場合の取得
+- `test_create_shelf`: 棚の新規作成
+- `test_get_shelf_detail`: 詳細取得
+- `test_update_shelf` / `test_update_shelf_not_found`: 更新成功と404
+- `test_delete_shelf` / `test_delete_shelf_not_found`: 削除成功と404
 
 ## テストフィクスチャ
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -152,3 +152,32 @@ def sample_books(book_factory):
         isbn="9780987654321"
     )
     return [book1, book2]
+
+
+@pytest.fixture
+def shelf_factory(test_db):
+    """棚データ作成用ファクトリ"""
+    from app.models import Shelf
+
+    def _create_shelf(**kwargs):
+        defaults = {
+            "name": "living",
+            "memo": "リビング棚",
+        }
+        defaults.update(kwargs)
+
+        shelf = Shelf(**defaults)
+        test_db.add(shelf)
+        test_db.commit()
+        test_db.refresh(shelf)
+        return shelf
+
+    return _create_shelf
+
+
+@pytest.fixture
+def sample_shelves(shelf_factory):
+    """2件分の棚データ"""
+    shelf1 = shelf_factory(name="living", memo="リビング")
+    shelf2 = shelf_factory(name="bedroom", memo="寝室")
+    return [shelf1, shelf2]

--- a/backend/tests/test_shelves.py
+++ b/backend/tests/test_shelves.py
@@ -1,0 +1,61 @@
+from fastapi.testclient import TestClient
+
+
+def test_get_shelves_empty(client: TestClient):
+    response = client.get("/shelves/")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_get_shelves_with_data(client: TestClient, sample_shelves):
+    response = client.get("/shelves/")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    assert data[0]["name"] == sample_shelves[0].name
+
+
+def test_create_shelf(client: TestClient):
+    payload = {"name": "study", "memo": "書斎の棚"}
+    response = client.post("/shelves/", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] > 0
+    assert data["name"] == payload["name"]
+    assert data["memo"] == payload["memo"]
+
+
+def test_get_shelf_detail(client: TestClient, shelf_factory):
+    shelf = shelf_factory(name="kidroom", memo="子ども部屋")
+    response = client.get(f"/shelves/{shelf.id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "kidroom"
+
+
+def test_update_shelf(client: TestClient, shelf_factory):
+    shelf = shelf_factory(name="garage", memo="ガレージ")
+    response = client.put(
+        f"/shelves/{shelf.id}", json={"name": "garage-new", "memo": "整理済み"}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "garage-new"
+    assert data["memo"] == "整理済み"
+
+
+def test_update_shelf_not_found(client: TestClient):
+    response = client.put("/shelves/999", json={"name": "missing"})
+    assert response.status_code == 404
+
+
+def test_delete_shelf(client: TestClient, shelf_factory):
+    shelf = shelf_factory(name="closet", memo="クローゼット")
+    response = client.delete(f"/shelves/{shelf.id}")
+    assert response.status_code == 200
+    assert response.json()["message"] == "Shelf deleted successfully"
+
+
+def test_delete_shelf_not_found(client: TestClient):
+    response = client.delete("/shelves/999")
+    assert response.status_code == 404

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -122,6 +122,79 @@ button:hover {
   gap: 0.5rem;
 }
 
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.shelf-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+.shelf-table th,
+.shelf-table td {
+  border: 1px solid #e0e0e0;
+  padding: 0.75rem;
+  text-align: left;
+}
+
+.shelf-table th {
+  background: #f8f8f8;
+}
+
+.table-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.shelf-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.shelf-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 500;
+}
+
+.shelf-form input,
+.shelf-form textarea {
+  padding: 0.5rem;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  font-size: 1rem;
+}
+
+.shelf-detail dl {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 0.5rem 1rem;
+  margin: 1rem 0;
+}
+
+.shelf-detail dt {
+  font-weight: bold;
+}
+
+.shelf-delete {
+  margin-top: 1rem;
+}
+
+.error {
+  color: #c0392b;
+  margin-top: 0.5rem;
+}
+
 @media (prefers-color-scheme: dark) {
   html {
     color-scheme: dark;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -22,6 +22,9 @@ export default function RootLayout({
               <li>
                 <Link href="/books">Book List</Link>
               </li>
+              <li>
+                <Link href="/shelves">Shelves</Link>
+              </li>
             </ul>
           </nav>
 

--- a/frontend/app/shelves/[id]/edit/page.tsx
+++ b/frontend/app/shelves/[id]/edit/page.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import { ShelfForm } from "@/app/shelves/_components/ShelfForm";
+import { ShelfDeleteButton } from "@/app/shelves/_components/ShelfDeleteButton";
+import { deleteShelf, fetchShelf, updateShelf } from "@/lib/api/shelves";
+import type { Shelf, ShelfFormData } from "@/types/shelf";
+
+export default function EditShelfPage() {
+  const params = useParams();
+  const router = useRouter();
+  const [shelf, setShelf] = useState<Shelf | null>(null);
+  const [error, setError] = useState<string>("");
+
+  useEffect(() => {
+    const load = async () => {
+      setError("");
+      try {
+        const id = Number(params.id);
+        const data = await fetchShelf(id);
+        setShelf(data);
+      } catch (err) {
+        setError(`${err}`);
+      }
+    };
+    load();
+  }, [params.id]);
+
+  const handleSubmit = async (data: ShelfFormData) => {
+    if (!shelf) return;
+    await updateShelf(shelf.id, data);
+    router.push(`/shelves/${shelf.id}`);
+  };
+
+  const handleDelete = async () => {
+    if (!shelf) return;
+    await deleteShelf(shelf.id);
+    router.push("/shelves");
+  };
+
+  if (error) {
+    return <div className="container">エラー: {error}</div>;
+  }
+
+  if (!shelf) {
+    return <div className="container">読み込み中...</div>;
+  }
+
+  return (
+    <div className="container">
+      <h2>棚の編集</h2>
+      <ShelfForm
+        initialData={{ name: shelf.name, memo: shelf.memo }}
+        onSubmit={handleSubmit}
+        submitLabel="更新する"
+      />
+      <ShelfDeleteButton onDelete={handleDelete} />
+      <Link href={`/shelves/${shelf.id}`}>
+        <button type="button">詳細に戻る</button>
+      </Link>
+    </div>
+  );
+}

--- a/frontend/app/shelves/[id]/page.tsx
+++ b/frontend/app/shelves/[id]/page.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { ShelfDetail } from "@/app/shelves/_components/ShelfDetail";
+import { fetchShelf } from "@/lib/api/shelves";
+import type { Shelf } from "@/types/shelf";
+
+export default function ShelfDetailPage() {
+  const params = useParams();
+  const [shelf, setShelf] = useState<Shelf | null>(null);
+  const [error, setError] = useState<string>("");
+
+  useEffect(() => {
+    const load = async () => {
+      setError("");
+      try {
+        const id = Number(params.id);
+        const data = await fetchShelf(id);
+        setShelf(data);
+      } catch (err) {
+        setError(`${err}`);
+      }
+    };
+    load();
+  }, [params.id]);
+
+  if (error) {
+    return <div className="container">エラー: {error}</div>;
+  }
+
+  if (!shelf) {
+    return <div className="container">読み込み中...</div>;
+  }
+
+  return (
+    <div className="container">
+      <ShelfDetail shelf={shelf} />
+    </div>
+  );
+}

--- a/frontend/app/shelves/_components/ShelfDeleteButton.tsx
+++ b/frontend/app/shelves/_components/ShelfDeleteButton.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState } from "react";
+
+type Props = {
+  onDelete: () => Promise<void>;
+};
+
+export function ShelfDeleteButton({ onDelete }: Props) {
+  const [error, setError] = useState<string>("");
+  const [isDeleting, setIsDeleting] = useState<boolean>(false);
+
+  const handleClick = async () => {
+    if (!confirm("本当に削除しますか？")) {
+      return;
+    }
+    setIsDeleting(true);
+    setError("");
+    try {
+      await onDelete();
+    } catch (err) {
+      setError(`${err}`);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <div className="shelf-delete">
+      <button type="button" onClick={handleClick} disabled={isDeleting}>
+        {isDeleting ? "削除中..." : "棚を削除"}
+      </button>
+      {error && <div className="error">エラー: {error}</div>}
+    </div>
+  );
+}

--- a/frontend/app/shelves/_components/ShelfDetail.tsx
+++ b/frontend/app/shelves/_components/ShelfDetail.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+import type { Shelf } from "@/types/shelf";
+
+type Props = {
+  shelf: Shelf;
+};
+
+export function ShelfDetail({ shelf }: Props) {
+  return (
+    <div className="shelf-detail">
+      <h2>棚詳細</h2>
+      <dl>
+        <dt>名称</dt>
+        <dd>{shelf.name}</dd>
+        <dt>メモ</dt>
+        <dd>{shelf.memo ?? "-"}</dd>
+      </dl>
+      <div className="form-actions">
+        <Link href={`/shelves/${shelf.id}/edit`}>
+          <button type="button">編集</button>
+        </Link>
+        <Link href="/shelves">
+          <button type="button">一覧に戻る</button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/shelves/_components/ShelfForm.tsx
+++ b/frontend/app/shelves/_components/ShelfForm.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+import type { ShelfFormData } from "@/types/shelf";
+
+type Props = {
+  initialData?: ShelfFormData;
+  onSubmit: (data: ShelfFormData) => Promise<void>;
+  submitLabel: string;
+};
+
+export function ShelfForm({ initialData, onSubmit, submitLabel }: Props) {
+  const [formData, setFormData] = useState<ShelfFormData>(
+    initialData ?? {
+      name: "",
+      memo: "",
+    }
+  );
+  const [error, setError] = useState<string>("");
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError("");
+    setIsSubmitting(true);
+    try {
+      if (!formData.name) {
+        throw new Error("棚名は必須です");
+      }
+      await onSubmit({
+        name: formData.name,
+        memo: formData.memo ?? "",
+      });
+    } catch (err) {
+      setError(`${err}`);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form className="shelf-form" onSubmit={handleSubmit}>
+      <label>
+        棚の名称
+        <input
+          type="text"
+          name="name"
+          value={formData.name}
+          onChange={handleChange}
+          required
+        />
+      </label>
+      <label>
+        メモ
+        <textarea
+          name="memo"
+          value={formData.memo ?? ""}
+          onChange={handleChange}
+          rows={4}
+        />
+      </label>
+      {error && <div className="error">エラー: {error}</div>}
+      <div className="form-actions">
+        <button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? "送信中..." : submitLabel}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/app/shelves/_components/ShelfList.tsx
+++ b/frontend/app/shelves/_components/ShelfList.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import type { Shelf } from "@/types/shelf";
+
+type Props = {
+  shelves: Shelf[];
+  error?: string;
+  isLoading?: boolean;
+};
+
+export function ShelfList({ shelves, error, isLoading }: Props) {
+  if (isLoading) {
+    return <div>棚情報を取得中です...</div>;
+  }
+
+  if (error) {
+    return <div className="error">エラー: {error}</div>;
+  }
+
+  if (shelves.length === 0) {
+    return <div>登録済みの棚はありません</div>;
+  }
+
+  return (
+    <table className="shelf-table">
+      <thead>
+        <tr>
+          <th>名称</th>
+          <th>メモ</th>
+          <th>操作</th>
+        </tr>
+      </thead>
+      <tbody>
+        {shelves.map((shelf) => (
+          <tr key={shelf.id}>
+            <td>{shelf.name}</td>
+            <td>{shelf.memo ?? "-"}</td>
+            <td>
+              <div className="table-actions">
+                <Link href={`/shelves/${shelf.id}`}>詳細</Link>
+                <Link href={`/shelves/${shelf.id}/edit`}>編集</Link>
+              </div>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/app/shelves/new/page.tsx
+++ b/frontend/app/shelves/new/page.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { ShelfForm } from "@/app/shelves/_components/ShelfForm";
+import { createShelf } from "@/lib/api/shelves";
+
+export default function NewShelfPage() {
+  const router = useRouter();
+
+  const handleSubmit = async (data: { name: string; memo: string | null }) => {
+    await createShelf(data);
+    router.push("/shelves");
+  };
+
+  return (
+    <div className="container">
+      <h2>棚の新規登録</h2>
+      <ShelfForm onSubmit={handleSubmit} submitLabel="登録する" />
+      <Link href="/shelves">
+        <button type="button">一覧に戻る</button>
+      </Link>
+    </div>
+  );
+}

--- a/frontend/app/shelves/page.tsx
+++ b/frontend/app/shelves/page.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import type { Shelf } from "@/types/shelf";
+import { fetchShelves } from "@/lib/api/shelves";
+import { ShelfList } from "@/app/shelves/_components/ShelfList";
+
+export default function ShelfListPage() {
+  const [shelves, setShelves] = useState<Shelf[]>([]);
+  const [error, setError] = useState<string>("");
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    const load = async () => {
+      setIsLoading(true);
+      setError("");
+      try {
+        const data = await fetchShelves();
+        setShelves(data);
+      } catch (err) {
+        setError(`${err}`);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  return (
+    <div className="container">
+      <div className="page-header">
+        <h2>棚一覧</h2>
+        <Link href="/shelves/new">
+          <button type="button">棚を追加</button>
+        </Link>
+      </div>
+      <ShelfList shelves={shelves} error={error} isLoading={isLoading} />
+    </div>
+  );
+}

--- a/frontend/lib/api/books.ts
+++ b/frontend/lib/api/books.ts
@@ -1,12 +1,5 @@
 import type { Book } from "@/types/book";
-
-const getApiBaseUrl = () => {
-  const url = process.env.NEXT_PUBLIC_API_URL;
-  if (!url) {
-    throw new Error("NEXT_PUBLIC_API_URL環境変数が設定されていません");
-  }
-  return url;
-};
+import { getApiBaseUrl } from "./client";
 
 export const fetchApiStatus = async (): Promise<string> => {
   const apiBaseUrl = getApiBaseUrl();

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -1,0 +1,7 @@
+export const getApiBaseUrl = (): string => {
+  const url = process.env.NEXT_PUBLIC_API_URL;
+  if (!url) {
+    throw new Error("NEXT_PUBLIC_API_URL環境変数が設定されていません");
+  }
+  return url;
+};

--- a/frontend/lib/api/lookup.ts
+++ b/frontend/lib/api/lookup.ts
@@ -1,12 +1,5 @@
 import type { GoogleBooksResponse } from "@/types/lookup";
-
-const getApiBaseUrl = () => {
-  const url = process.env.NEXT_PUBLIC_API_URL;
-  if (!url) {
-    throw new Error("NEXT_PUBLIC_API_URL環境変数が設定されていません");
-  }
-  return url;
-};
+import { getApiBaseUrl } from "./client";
 
 export const lookupBookByIsbn = async (
   isbn: string

--- a/frontend/lib/api/shelves.ts
+++ b/frontend/lib/api/shelves.ts
@@ -1,0 +1,72 @@
+import type { Shelf, ShelfFormData } from "@/types/shelf";
+import { getApiBaseUrl } from "./client";
+
+export const fetchShelves = async (): Promise<Shelf[]> => {
+  const apiBaseUrl = getApiBaseUrl();
+  const res = await fetch(`${apiBaseUrl}/shelves/`);
+  if (!res.ok) {
+    throw new Error("棚情報の取得に失敗しました");
+  }
+  return await res.json();
+};
+
+export const fetchShelf = async (id: number): Promise<Shelf> => {
+  const apiBaseUrl = getApiBaseUrl();
+  const res = await fetch(`${apiBaseUrl}/shelves/${id}`);
+  if (!res.ok) {
+    if (res.status === 404) {
+      throw new Error("棚が見つかりません");
+    }
+    throw new Error("棚情報の取得に失敗しました");
+  }
+  return await res.json();
+};
+
+export const createShelf = async (formData: ShelfFormData): Promise<Shelf> => {
+  const apiBaseUrl = getApiBaseUrl();
+  const res = await fetch(`${apiBaseUrl}/shelves/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(formData),
+  });
+  if (!res.ok) {
+    throw new Error("棚の登録に失敗しました");
+  }
+  return await res.json();
+};
+
+export const updateShelf = async (
+  id: number,
+  formData: Partial<ShelfFormData>
+): Promise<Shelf> => {
+  const apiBaseUrl = getApiBaseUrl();
+  const res = await fetch(`${apiBaseUrl}/shelves/${id}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(formData),
+  });
+  if (!res.ok) {
+    if (res.status === 404) {
+      throw new Error("棚が見つかりません");
+    }
+    throw new Error("棚の更新に失敗しました");
+  }
+  return await res.json();
+};
+
+export const deleteShelf = async (id: number): Promise<void> => {
+  const apiBaseUrl = getApiBaseUrl();
+  const res = await fetch(`${apiBaseUrl}/shelves/${id}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) {
+    if (res.status === 404) {
+      throw new Error("棚が見つかりません");
+    }
+    throw new Error("棚の削除に失敗しました");
+  }
+};

--- a/frontend/types/shelf.ts
+++ b/frontend/types/shelf.ts
@@ -1,0 +1,10 @@
+export type Shelf = {
+  id: number;
+  name: string;
+  memo: string | null;
+};
+
+export type ShelfFormData = {
+  name: string;
+  memo: string | null;
+};


### PR DESCRIPTION
## Summary
- add a Shelf SQLAlchemy model, Pydantic schemas, router, and pytest coverage for the new CRUD endpoints
- introduce shelf API helpers, types, pages, and components on the frontend together with shared API client utilities and styling updates
- default the backend database URL to a local SQLite database so the new and existing tests run without extra configuration

## Testing
- `cd backend/app && uv run pytest ../tests`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a9dd80474832890d27ff67f2d65a9)