### PR TITLE
Auth0の識別子をUserに追加し `get_current_user` で未登録時に作成するよう変更

### DIFF
--- a/backend/app/context.py
+++ b/backend/app/context.py
@@ -1,7 +1,8 @@
 """APIリクエストのユーザーコンテキスト管理"""
 import logging
+from datetime import datetime, timezone
 from typing import Annotated
-from fastapi import Depends
+from fastapi import Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 
 from .database import get_db
@@ -10,27 +11,46 @@ from .models import User
 logger = logging.getLogger(__name__)
 
 
-def get_current_user(db: Session = Depends(get_db)) -> User:
+def _extract_auth0_identity(request: Request) -> tuple[str, str]:
+    auth0_sub = request.headers.get("X-Auth0-Sub")
+    email = request.headers.get("X-Auth0-Email")
+
+    if not auth0_sub:
+        raise HTTPException(status_code=401, detail="認証情報がありません")
+    if not email:
+        raise HTTPException(status_code=400, detail="メールアドレスがありません")
+
+    return auth0_sub, email
+
+
+def get_current_user(
+    request: Request,
+    db: Session = Depends(get_db)
+) -> User:
     """
     現在のユーザーコンテキストを取得する。
-    現在の実装: 常に管理者ユーザー（id=1）を返す。存在しない場合は自動作成する。
-    認証実装後: 認証情報から実際のユーザーを判定する。
+    認証情報の sub を使ってユーザーを取得し、未登録なら自動作成する。
 
     Returns:
-        User: 現在のユーザー（現在は管理者のみ）
+        User: 現在のユーザー
 
     Raises:
-        RuntimeError: 管理者ユーザーの作成/取得に失敗した場合
+        HTTPException: 認証情報が不足している場合
     """
-    user = db.query(User).filter(User.id == 1).first()
+    auth0_sub, email = _extract_auth0_identity(request)
+    user = db.query(User).filter(User.auth0_sub == auth0_sub).first()
 
     if not user:
-        # 最初のアクセス時に管理者ユーザーを自動作成
-        user = User(id=1, name="admin")
+        user = User(
+            auth0_sub=auth0_sub,
+            email=email,
+            name=email,
+            created_at=datetime.now(timezone.utc)
+        )
         db.add(user)
         db.commit()
         db.refresh(user)
-        logger.info("管理者ユーザー（id=1）を自動作成しました")
+        logger.info("ユーザーを新規作成しました: %s", auth0_sub)
 
     return user
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -47,6 +47,13 @@ class User(Base):
     __tablename__ = "users"
 
     id: Mapped[int] = mapped_column(primary_key=True)
+    auth0_sub: Mapped[str] = mapped_column(
+        String(255),
+        unique=True,
+        nullable=False,
+        index=True
+    )
+    email: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
     name: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/backend/app/router/users.py
+++ b/backend/app/router/users.py
@@ -38,6 +38,11 @@ def read_user(user_id: int, db: Session = Depends(get_db)):
 def create_user(user: UserCreate, db: Session = Depends(get_db)):
     """ユーザーを新規作成"""
     logger.info("POST /users - Creating user: name='%s'", user.name)
+    if not user.auth0_sub or not user.email:
+        raise HTTPException(
+            status_code=400,
+            detail="auth0_sub と email は必須です"
+        )
     try:
         db_user = User(**user.model_dump())
         db.add(db_user)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -125,6 +125,8 @@ class ShelfRead(ShelfBase):
 
 class UserBase(BaseModel):
     name: str
+    auth0_sub: str | None = None
+    email: str | None = None
 
 
 class UserCreate(UserBase):
@@ -133,6 +135,8 @@ class UserCreate(UserBase):
 
 class UserUpdate(BaseModel):
     name: str | None = None
+    auth0_sub: str | None = None
+    email: str | None = None
 
 
 class UserRead(UserBase):


### PR DESCRIPTION
### Motivation
- Auth0の`sub`でユーザーを一意に識別し、アプリ内で同一ユーザーとして扱えるようにするため。 
- 認証済みリクエストから受け取った情報で未登録ユーザーを自動作成して初回利用をスムーズにするため。 
- APIの依存関数が`User`エンティティを返すことで、以降のルーターで同一ユーザーオブジェクトを利用できるようにするため。 
- 手動でユーザーを作成する際にも`auth0_sub`と`email`の整合性を確保するため。 

### Description
- `users`テーブル/モデルに`auth0_sub`（ユニーク、必須）と`email`（必須）を追加しました（`backend/app/models.py`）。
- `get_current_user`を変更し、リクエストヘッダー`X-Auth0-Sub`と`X-Auth0-Email`から認証情報を取得してDB検索し、未登録なら`auth0_sub`, `email`, `created_at`を保存して新規作成するようにしました（`backend/app/context.py`）。
- Pydanticスキーマで`User`関連に`auth0_sub`/`email`を追加し、`UserCreate`エンドポイントで両者の存在を検証するバリデーションを追加しました（`backend/app/schemas.py`, `backend/app/router/users.py`）。
- 依存性注入の型エイリアス`CurrentUser`は引き続き`User`を返すよう維持し、以降のルーターは同一ユーザーとして扱えるようにしています（`backend/app/context.py`）。

### Testing
- 自動化テスト（`pytest`等）は実行していません。
- 変更はローカルでソース編集およびコミットまで行っていますが、統合テストは未実行です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963b876c4ac8328a17f946d799abd19)