### PR TITLE
[FE] Next.js API Routes プロキシ層を追加して同一オリジン化

### DIFF
--- a/frontend/.env.sample
+++ b/frontend/.env.sample
@@ -1,7 +1,9 @@
 # ===========================================
-# バックエンドAPI
+# バックエンドAPI（サーバ専用・ブラウザ非公開）
 # ===========================================
-NEXT_PUBLIC_API_URL=http://localhost:8000
+# Next.js のサーバ側（Route Handler / Server Component）から FastAPI を内部呼び出しする際の URL。
+# ブラウザは同一オリジンの /api/* を叩き、Route Handler がここを参照して FastAPI へ転送する。
+BACKEND_API_URL=http://localhost:8000
 
 # ===========================================
 # Auth0（必須）

--- a/frontend/app/api/[...path]/route.ts
+++ b/frontend/app/api/[...path]/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerAccessToken } from "@/lib/auth/token";
+
+/**
+ * FastAPI への汎用プロキシ Route Handler。
+ *
+ * ブラウザは同一オリジン `/api/<path>` を叩き、ここでサーバ側で Auth0 アクセストークンを
+ * 付与した上で `BACKEND_API_URL/<path>` へ転送する。これによりブラウザにはアクセス
+ * トークンが露出せず、CORS も不要になる。
+ *
+ * クエリ文字列・リクエストボディ・Content-Type はそのまま素通しする。
+ * lookup のような認証不要エンドポイントにもトークンを付けて送るが、FastAPI 側で
+ * 単に無視されるため動作上の問題はない（パスベースの分岐を避けてシンプルに保つ）。
+ */
+async function proxy(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+): Promise<NextResponse> {
+  const backendBase = process.env.BACKEND_API_URL;
+  if (!backendBase) {
+    return NextResponse.json(
+      { error: "BACKEND_API_URL is not configured" },
+      { status: 500 },
+    );
+  }
+
+  const { path } = await params;
+  const url = new URL(request.url);
+  const target = `${backendBase}/${path.join("/")}${url.search}`;
+
+  const headers = new Headers();
+  const contentType = request.headers.get("content-type");
+  if (contentType) {
+    headers.set("content-type", contentType);
+  }
+  const accept = request.headers.get("accept");
+  if (accept) {
+    headers.set("accept", accept);
+  }
+
+  const accessToken = await getServerAccessToken();
+  if (accessToken) {
+    headers.set("Authorization", `Bearer ${accessToken}`);
+  }
+
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+  };
+
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    init.body = await request.text();
+  }
+
+  const upstream = await fetch(target, init);
+
+  const responseHeaders = new Headers();
+  const upstreamContentType = upstream.headers.get("content-type");
+  if (upstreamContentType) {
+    responseHeaders.set("content-type", upstreamContentType);
+  }
+
+  return new NextResponse(upstream.body, {
+    status: upstream.status,
+    headers: responseHeaders,
+  });
+}
+
+export const GET = proxy;
+export const POST = proxy;
+export const PUT = proxy;
+export const PATCH = proxy;
+export const DELETE = proxy;

--- a/frontend/lib/api/authenticatedFetch.ts
+++ b/frontend/lib/api/authenticatedFetch.ts
@@ -1,44 +1,43 @@
-import { getServerAccessToken, getClientAccessToken } from "@/lib/auth/token";
+import { getServerAccessToken } from "@/lib/auth/token";
 
-/**
- * サーバーまたはクライアントで実行中かを判定
- */
 function isServer(): boolean {
   return typeof window === "undefined";
 }
 
 /**
- * 認証付きfetchラッパー - Authorizationヘッダーを自動追加
+ * fetch ラッパー。
  *
- * Server Componentでの使用例:
- *   const data = await authenticatedFetch("/books");
+ * サーバ側（Server Component / Route Handler 内）では `getServerAccessToken()`
+ * で Auth0 アクセストークンを取得し `Authorization: Bearer ...` を付与する。
  *
- * Client Componentでの使用例:
- *   const data = await authenticatedFetch("/books", { method: "POST", ... });
+ * ブラウザ側（Client Component）からは同一オリジンの `/api/*` を叩く構成のため、
+ * トークン付与は Next.js の Route Handler 側に集約されている。ここではトークンを
+ * 付けずに同一オリジン fetch をそのまま実行する（Cookie ベースのセッションで
+ * Route Handler 側がユーザーを特定する）。
+ *
+ * 使用例（Server Component）:
+ *   const data = await authenticatedFetch(`${apiBaseUrl}/books`);
+ *
+ * 使用例（Client Component）:
+ *   const data = await authenticatedFetch("/api/books", { method: "POST", ... });
  */
 export async function authenticatedFetch(
   url: string,
   options?: RequestInit,
 ): Promise<Response> {
-  // コンテキストに基づいてトークンを取得
-  const accessToken = isServer()
-    ? await getServerAccessToken()
-    : await getClientAccessToken();
-
-  // 認証付きヘッダーを構築
   const headers = new Headers(options?.headers);
 
-  // JSON API用にContent-Typeを常に設定
   if (!headers.has("Content-Type")) {
     headers.set("Content-Type", "application/json");
   }
 
-  // トークンがあればAuthorizationヘッダーを追加
-  if (accessToken) {
-    headers.set("Authorization", `Bearer ${accessToken}`);
+  if (isServer()) {
+    const accessToken = await getServerAccessToken();
+    if (accessToken) {
+      headers.set("Authorization", `Bearer ${accessToken}`);
+    }
   }
 
-  // 拡張ヘッダーでリクエストを実行
   return fetch(url, {
     ...options,
     headers,

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -1,7 +1,18 @@
+/**
+ * API のベース URL を返す。
+ *
+ * - サーバ側（Route Handler / Server Component）: `BACKEND_API_URL` を返し、
+ *   FastAPI を内部ネットワーク経由で直接叩く。
+ * - ブラウザ側（Client Component）: 同一オリジンの `/api` を返し、
+ *   Next.js の Route Handler 経由で FastAPI へプロキシされる。
+ */
 export const getApiBaseUrl = (): string => {
-  const url = process.env.NEXT_PUBLIC_API_URL;
-  if (!url) {
-    throw new Error("NEXT_PUBLIC_API_URL環境変数が設定されていません");
+  if (typeof window === "undefined") {
+    const url = process.env.BACKEND_API_URL;
+    if (!url) {
+      throw new Error("BACKEND_API_URL環境変数が設定されていません");
+    }
+    return url;
   }
-  return url;
+  return "/api";
 };

--- a/frontend/lib/auth/token.ts
+++ b/frontend/lib/auth/token.ts
@@ -1,11 +1,10 @@
 import { auth0, hasAuth0Error } from "@/lib/auth0";
 
 /**
- * Server ComponentまたはServer Actionでアクセストークンを取得
- * これが推奨方法 - トークンはサーバー側に留まる
+ * Server Component / Server Action / Route Handler 内で Auth0 アクセストークンを取得する。
+ * トークンはサーバ側に留まる。
  */
 export async function getServerAccessToken(): Promise<string | null> {
-  // Auth0が初期化されていない場合はnullを返す
   if (hasAuth0Error) {
     return null;
   }
@@ -20,27 +19,6 @@ export async function getServerAccessToken(): Promise<string | null> {
     return token ?? null;
   } catch (error) {
     console.error("Failed to get server access token:", error);
-    return null;
-  }
-}
-
-/**
- * Client Componentでアクセストークンを取得
- * 組み込みの/auth/access-tokenエンドポイントを使用
- * 注意: トークンがブラウザに露出される
- */
-export async function getClientAccessToken(): Promise<string | null> {
-  try {
-    const response = await fetch("/auth/access-token");
-    if (!response.ok) {
-      return null;
-    }
-
-    const data = await response.json();
-    // Auth0 SDK v4では { token } 形式
-    return data.token ?? null;
-  } catch (error) {
-    console.error("Failed to get client access token:", error);
     return null;
   }
 }


### PR DESCRIPTION
## 概要

ブラウザは同一オリジン `/api/*`（Next.js）を叩き、Next.js のサーバ側（Route Handler）から内部的に FastAPI を呼ぶ構成に切り替えた。Auth0 アクセストークン付与は Route Handler 側に集約し、ブラウザに露出しないようにした。

## 変更点

- **`frontend/app/api/[...path]/route.ts`**: FastAPI への汎用プロキシ Route Handler（キャッチオール）を新設。GET/POST/PUT/PATCH/DELETE をすべて同じハンドラで処理し、サーバ側で `getServerAccessToken()` から Auth0 トークンを取得して `Authorization: Bearer ...` を付けて `BACKEND_API_URL` に転送する。
- **`frontend/lib/api/client.ts`**: `getApiBaseUrl()` を context aware に変更。サーバ側（Server Component / Route Handler）では `BACKEND_API_URL` を返し、ブラウザ側では `/api` を返す。これにより `lib/api/*.ts`（books / shelves / lookup / userBooks）のコードは変更不要で server/client の両方で動作する。
- **`frontend/lib/api/authenticatedFetch.ts`**: サーバコンテキストでのみ `getServerAccessToken` でトークン付与し、クライアントコンテキストでは付与をスキップ（Route Handler 側で付与されるため）。
- **`frontend/lib/auth/token.ts`**: 不要になった `getClientAccessToken()` を削除（ブラウザ側でトークンを取りに行く経路を廃止）。
- **`frontend/.env.sample`**: `NEXT_PUBLIC_API_URL` を廃止し `BACKEND_API_URL`（サーバ専用）に差し替え。

## 設計上の判断

- **Server Component (`app/books/page.tsx`) は引き続き直接 FastAPI を叩く**: `/api` 経由にすると同一プロセス内で HTTP ホップが増えて非効率なため、サーバ側は `BACKEND_API_URL` を直接参照する経路を維持した（context 分岐で自動切替）。Server Component 側のコード変更はゼロ。
- **Route Handler はキャッチオール 1 ファイル**: プロキシ層なのでリソースごとの個別変換ロジックは不要。エンドポイント追加時の追従もゼロ。lookup（認証不要）にもトークンを付けて送るが、FastAPI 側で無視されるためパスベース分岐は省略してシンプルに保った。

## 環境変数の変更

`frontend/.env` で以下を差し替えてください。

```diff
- NEXT_PUBLIC_API_URL=http://localhost:8000
+ BACKEND_API_URL=http://localhost:8000
```

compose 環境では兄弟子 #21 で `BACKEND_API_URL=http://backend:8000` を frontend サービスに設定する想定。

## テスト

- ホスト側に `frontend/node_modules` が無い構成のため、型チェック・lint は本 PR ではローカル実行未確認。compose 経由でビルド & 動作確認を推奨。
- 影響範囲: `lib/api/*.ts` の全 fetch、`authenticatedFetch`、`getApiBaseUrl`、`books/page.tsx`（Server Component）。

Closes #19