### PR TITLE
🌳 🤖 [infra] compose.yaml で backend のホストポート公開を停止し frontend に BACKEND_API_URL を設定

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -7,13 +7,15 @@ services:
     volumes:
       - ./data:/data
       - ./backend/logs:/app/logs
-    ports:
-      - "8000:8000"
+    expose:
+      - "8000"
     restart: unless-stopped
 
   frontend:
     build: ./frontend
     env_file: ./frontend/.env
+    environment:
+      BACKEND_API_URL: http://backend:8000
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
## 概要

ワンオリジン化（#18 / #19）でブラウザから backend に直接到達しなくなるため、`compose.yaml` で backend のホストポート公開を止め、内部ネットワーク経由で frontend からのみアクセスできる構成に変更する。

## 変更点

- `compose.yaml` の backend サービス: `ports: ["8000:8000"]` を削除し、`expose: ["8000"]` に変更（内部 API であることを明示）
- `compose.yaml` の frontend サービス: `environment` に `BACKEND_API_URL: http://backend:8000` を追加（コンテナ間の内部ネットワーク名で参照）

## 備考

- frontend の `env_file` には `BACKEND_API_URL=http://localhost:8000` がデフォルト記載されているが、compose の `environment:` ブロックが env_file より優先されるため、docker 経由では `http://backend:8000` が使われる
- 兄弟子 #20（CORS 撤去）とは独立に進行可能

Closes #21