### PR TITLE
🤖 [FE] .env.sample の AUTH0_BASE_URL を APP_BASE_URL に修正（@auth0/nextjs-auth0 v4 対応）

### DIFF
--- a/frontend/.env.sample
+++ b/frontend/.env.sample
@@ -11,6 +11,6 @@ BACKEND_API_URL=http://localhost:8000
 AUTH0_DOMAIN=your-tenant.auth0.com
 AUTH0_CLIENT_ID=your-client-id
 AUTH0_CLIENT_SECRET=your-client-secret
-AUTH0_BASE_URL=http://localhost:3000
+APP_BASE_URL=http://localhost:3000
 AUTH0_AUDIENCE=your-api-identifier
 AUTH0_SECRET=your-random-secret-at-least-32-chars


### PR DESCRIPTION
## 概要

`@auth0/nextjs-auth0` v4 で base URL の env 名が `AUTH0_BASE_URL` → `APP_BASE_URL` にリネームされたが、`frontend/.env.sample` は v3 時代の `AUTH0_BASE_URL` のまま残っていて、新規環境構築時に SDK が値を読めず middleware が `TypeError: Invalid URL` で落ちる問題を修正する。

## 変更点

- `frontend/.env.sample`: `AUTH0_BASE_URL=http://localhost:3000` を `APP_BASE_URL=http://localhost:3000` に書き換え

## 確認

- `frontend/` 配下を `grep -r AUTH0_BASE_URL` で確認し、`.env.sample` の 1 行以外に残骸が無いことを確認済み（コード／ドキュメントへの参照なし）

## フォロー

- 既存ローカル環境の `frontend/.env` 側も合わせて `AUTH0_BASE_URL` → `APP_BASE_URL` に差し替えが必要（個別対応）

Closes #23