### PR TITLE
👀 [FE] トップページの書籍0件時に空状態UI（まずは書籍登録を）を表示

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,13 +1,38 @@
+import Link from "next/link";
 import RandomBookList from "@/app/books/_components/RandomBookList";
 import LatestBookList from "@/app/books/_components/LatestBookList";
 import LoginPrompt from "@/app/components/LoginPrompt";
 import { auth0 } from "@/lib/auth0";
+import { fetchLatestBooks } from "@/lib/api/books";
 
 export default async function Home() {
   const session = await auth0.getSession();
 
   if (!session) {
     return <LoginPrompt showDescription={true} title="ログインして始めましょう" />;
+  }
+
+  // 取得失敗時はフォールバックとして既存の2ブロック表示に倒す
+  let hasBooks = true;
+  try {
+    const latest = await fetchLatestBooks(1);
+    hasBooks = latest.length > 0;
+  } catch (error) {
+    console.error("Failed to fetch latest books:", error);
+  }
+
+  if (!hasBooks) {
+    return (
+      <section>
+        <h2>まずは書籍登録をしましょう</h2>
+        <p>
+          書籍を登録すると、ランダムに1冊を取り出したり、最近の登録を一覧で見られるようになります。
+        </p>
+        <Link href="/books/new" className="button">
+          書籍を登録する
+        </Link>
+      </section>
+    );
   }
 
   return (


### PR DESCRIPTION
## 概要

トップページ (`/`) で書籍登録が0件のとき、「ランダム取得」ブロックが API エラー扱いになり「書籍情報の取得に失敗しました」と表示されていた。空状態として違和感があったため、サーバー側で件数を判定し、0件のときは「まずは書籍登録をしましょう」の統合空状態UIに置き換える。

## 変更点

- `frontend/app/page.tsx` をサーバー側で `fetchLatestBooks(1)` を呼んで件数を判定
- **0件のとき**: `RandomBookList`/`LatestBookList` を出さず、誘導文言と `/books/new` への導線リンクをまとめた単一セクションを表示
- **1件以上のとき**: 従来通り「ランダム取得」「最近の登録」の2ブロック表示を維持
- 件数取得が例外で失敗した場合は従来挙動（2ブロック表示）にフォールバック

## 備考

- 件数取得は `fetchLatestBooks(1)` を流用しており、件数API追加は行っていない
- `RandomBookList`/`LatestBookList` 内のエラー文言ロジックは変更していない（0件と分かっている時は呼ばないためランダム取得エラーは出ない）

Closes #29